### PR TITLE
Update UnifiedMapRenderer.cs

### DIFF
--- a/UnifiedMap/UnifiedMap.Droid/UnifiedMapRenderer.cs
+++ b/UnifiedMap/UnifiedMap.Droid/UnifiedMapRenderer.cs
@@ -98,8 +98,8 @@ namespace fivenine.UnifiedMaps.Droid
             }
 
             var mapRegion = _googleMap.Projection.VisibleRegion.LatLngBounds;
-            var region = new MapRegion(mapRegion.Northeast.Latitude, mapRegion.Southwest.Longitude,
-                                       mapRegion.Southwest.Latitude, mapRegion.Northeast.Longitude);
+            var region = new MapRegion(mapRegion.Southwest.Longitude, mapRegion.Northeast.Latitude,
+                                       mapRegion.Northeast.Longitude, mapRegion.Southwest.Latitude);
 
             Map.VisibleRegion = region;
         }

--- a/UnifiedMap/UnifiedMap.iOS/UnifiedMapRenderer.cs
+++ b/UnifiedMap/UnifiedMap.iOS/UnifiedMapRenderer.cs
@@ -176,7 +176,7 @@ namespace fivenine.UnifiedMaps.iOS
             
             if(newItem == null) return;
 
-            UnifiedDelegate.SetSelectedAnnotation(Control, newItem);
+            Control.SelectAnnotation(newItem, true);
         }
 
         protected override void OnElementChanged(ElementChangedEventArgs<UnifiedMap> e)


### PR DESCRIPTION
#21 Correct the order of parameters for Droid MapRegion construction in OnCameraChanged method

#17  Call select annotation so annotation pops up when SelectedItem is changed. (This was originally fixed by @steve-himself , but the change got merged out somehow?)