### PR TITLE
set map.MyLocationEnabled according to isShowingUser

### DIFF
--- a/UnifiedMap/UnifiedMap.Droid/UnifiedMapRenderer.cs
+++ b/UnifiedMap/UnifiedMap.Droid/UnifiedMapRenderer.cs
@@ -259,6 +259,7 @@ namespace fivenine.UnifiedMaps.Droid
         {
             if (_googleMap != null)
             {
+                _googleMap.MyLocationEnabled = Element.IsShowingUser;
                 _googleMap.UiSettings.MyLocationButtonEnabled = Element.IsShowingUser;
             }
         }


### PR DESCRIPTION
Issue #23 - set GoogleMap.MyLocationEnabled according to IsShowingUser, to allow the user's location to be visible on map.