### PR TITLE
Fix item deselection issue and inconsistency between two versions

### DIFF
--- a/SampleApp/SampleApp/MapPage.xaml
+++ b/SampleApp/SampleApp/MapPage.xaml
@@ -45,6 +45,11 @@
 				Command="{Binding SelectCommand}"
 				CommandParameter="{StaticResource Next}" 
 				/>
+
+			<Button 
+				Text="Clear Selection" 
+				Command="{Binding ClearSelectionCommand}"
+				/>
 			</StackLayout>
         <StackLayout 
             Orientation="Horizontal"

--- a/SampleApp/SampleApp/UnifiedMapViewModel.cs
+++ b/SampleApp/SampleApp/UnifiedMapViewModel.cs
@@ -26,6 +26,7 @@ namespace Sample
         private readonly Command _addPolylineCommand;
         private readonly Command _removePolylineCommand;
         private readonly Command _selectCommand;
+        private readonly Command _clearSelectionCommand;
 
         private readonly LinkedList<IMapPin> _allPins;
         private readonly LinkedList<IMapOverlay> _allPolylines;
@@ -61,6 +62,9 @@ namespace Sample
 
             _selectCommand =
                 new Command<int>(SetSelectedItem, (arg) => Pins.Count > 0);
+
+            _clearSelectionCommand =
+                new Command(() => SelectedItem = null);
 
             _allPins = new LinkedList<IMapPin> (
                 new []
@@ -210,6 +214,8 @@ namespace Sample
         public ICommand RemovePolylineCommand => _removePolylineCommand;
 
         public ICommand SelectCommand => _selectCommand;
+
+        public ICommand ClearSelectionCommand => _clearSelectionCommand;
 
         [NotifyPropertyChangedInvocator]
         protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)

--- a/UnifiedMap/UnifiedMap.iOS/UnifiedMapDelegate.cs
+++ b/UnifiedMap/UnifiedMap.iOS/UnifiedMapDelegate.cs
@@ -91,12 +91,7 @@ namespace fivenine.UnifiedMaps.iOS
 
         public override void DidSelectAnnotationView(MKMapView mapView, MKAnnotationView view)
         {
-            if (_selectedAnnotation is UnifiedPointAnnotation)
-            {
-                var prevAnnotation = (UnifiedPointAnnotation)_selectedAnnotation;
-                UpdateImage(_selectedAnnotationView, prevAnnotation.Data, false);
-                UpdatePinColor(_selectedAnnotationView, prevAnnotation.Data, false);
-            }
+            DeselectPin();
 
             var unifiedPoint = view?.Annotation as UnifiedPointAnnotation;
             _selectedAnnotation = unifiedPoint;
@@ -111,6 +106,12 @@ namespace fivenine.UnifiedMaps.iOS
                 UpdatePinColor(view, unifiedPoint.Data, true);
             }
         }
+
+		public override void DidDeselectAnnotationView(MKMapView mapView, MKAnnotationView view)
+		{
+			// Fix issue where Pins already deselected internally but it's still highlighted on UI
+			DeselectPin();
+		}
 
         public override void CalloutAccessoryControlTapped(MKMapView mapView, MKAnnotationView view, UIControl control)
         {
@@ -167,5 +168,15 @@ namespace fivenine.UnifiedMaps.iOS
                 });
             }
         }
+
+		private void DeselectPin()
+		{
+			if (_selectedAnnotation is UnifiedPointAnnotation)
+			{
+				var prevAnnotation = (UnifiedPointAnnotation)_selectedAnnotation;
+				UpdateImage(_selectedAnnotationView, prevAnnotation.Data, false);
+				UpdatePinColor(_selectedAnnotationView, prevAnnotation.Data, false);
+			}
+		}
     }
 }

--- a/UnifiedMap/UnifiedMap.iOS/UnifiedMapRenderer.cs
+++ b/UnifiedMap/UnifiedMap.iOS/UnifiedMapRenderer.cs
@@ -173,8 +173,15 @@ namespace fivenine.UnifiedMaps.iOS
                 .OfType<IUnifiedAnnotation>()
                 .FirstOrDefault(point => point.Data == SelectedItem) 
                  as IMKAnnotation;
-            
-            if(newItem == null) return;
+
+            if (newItem == null)
+            {
+				// fix an issue where pins are not reset to default state when SelectedItem = null
+				foreach (var annotation in Control.Annotations)
+					Control.DeselectAnnotation(annotation, false);
+
+                return;
+            }
 
             Control.SelectAnnotation(newItem, true);
         }


### PR DESCRIPTION
Hi, thank you very much for Unified Maps. I'm a co-developer with Sam H., we noticed that there are two bugs with the selection and deselection of pins.

1. On iOS, whenever the map is tapped, internally iOS has already deselected all annotations (in MKMapView.Annotations), however this is not reflected on the UI, i.e. the pins are still highlighted. Similar issue also exist in Android.
2. On Android, the "map tap to deselect" feature did not exist, therefore we added the functionality to it.

We're wondering if you're able to merge it and update nuget please? Thank again :-)