### PR TITLE
Add conditional flags to enable/disable touch map to dismiss and show/hide native zoom and location buttons.

### DIFF
--- a/UnifiedMap/UnifiedMap.iOS/UnifiedMapRenderer.cs
+++ b/UnifiedMap/UnifiedMap.iOS/UnifiedMapRenderer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
@@ -8,6 +8,7 @@ using fivenine.UnifiedMaps;
 using fivenine.UnifiedMaps.iOS;
 using Foundation;
 using MapKit;
+using UIKit;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.iOS;
 
@@ -20,6 +21,7 @@ namespace fivenine.UnifiedMaps.iOS
     {
         private readonly RendererBehavior _behavior;
         private CLLocationManager _locationManager;
+		private bool _shouldNotDismiss;
 
         public UnifiedMapRenderer()
         {
@@ -33,7 +35,7 @@ namespace fivenine.UnifiedMaps.iOS
             get { return Element.SelectedItem; }
             set 
             {
-                if (!Element.SelectedItem.EqualsSafe(value))
+				if (!Element.SelectedItem.EqualsSafe(value))
                 {
                     Element.SelectedItem = value;
                 }
@@ -63,6 +65,11 @@ namespace fivenine.UnifiedMaps.iOS
         {
             Control.ScrollEnabled = Element.HasScrollEnabled;
         }
+
+		public void ApplyDisplayNativeControls()
+		{
+			// Does nothing as iOS does not have native zoom and location buttons
+		}
 
         public void ApplyMapType()
         {
@@ -182,7 +189,7 @@ namespace fivenine.UnifiedMaps.iOS
 
                 return;
             }
-
+			
             Control.SelectAnnotation(newItem, true);
         }
 
@@ -211,6 +218,51 @@ namespace fivenine.UnifiedMaps.iOS
                 _behavior.Initialize();
             }
         }
+
+		public override void TouchesBegan(NSSet touches, UIEvent evt)
+		{
+			base.TouchesBegan(touches, evt);
+			_shouldNotDismiss = false; // reset
+		}
+
+		public override void TouchesMoved(NSSet touches, UIEvent evt)
+		{
+			base.TouchesMoved(touches, evt);
+			_shouldNotDismiss = true;
+		}
+
+		public override void TouchesCancelled(NSSet touches, UIEvent evt)
+		{
+			base.TouchesCancelled(touches, evt);
+			_shouldNotDismiss = true;
+		}
+
+		public override void TouchesEnded(NSSet touches, UIEvent evt)
+		{
+			base.TouchesEnded(touches, evt);
+
+			// Add a conditional guard to deselect on map touch
+			if (Element != null && Element.ShouldDeselectOnMapTouch && _shouldNotDismiss)
+			{
+				var isAnnotation = false;
+				var touch = touches.FirstOrDefault() as UITouch;
+				if (touch != null && Control != null)
+				{
+					// Detect when an annotation is touched
+					// May be enhanced in the future to detect when an MKCircle, MKPolyline or MKPointAnnotaiton is touched
+					if (touch.View is MKAnnotationView)
+					{
+						isAnnotation = true;
+					}
+				}
+
+				if (!isAnnotation)
+				{
+					// Deselect annotation when map is touched
+					SelectedItem = null;
+				}
+			}
+		}
 
         protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
         {

--- a/UnifiedMap/UnifiedMap/RendererBehavior.cs
+++ b/UnifiedMap/UnifiedMap/RendererBehavior.cs
@@ -30,6 +30,8 @@ namespace fivenine.UnifiedMaps
         void ApplyMapType();
 
         void SetSelectedAnnotation();
+
+		void ApplyDisplayNativeControls();
     }
 
     internal class RendererBehavior
@@ -240,6 +242,11 @@ namespace fivenine.UnifiedMaps
             {
                 _renderer.ApplyMapType();
             }
+
+			if (propertyName == UnifiedMap.ShouldDisplayNativeControlsProperty.PropertyName)
+			{
+				_renderer.ApplyDisplayNativeControls();
+			}
 
             if (propertyName == UnifiedMap.IsShowingUserProperty.PropertyName)
             {

--- a/UnifiedMap/UnifiedMap/UnifiedMap.cs
+++ b/UnifiedMap/UnifiedMap/UnifiedMap.cs
@@ -62,6 +62,12 @@ namespace fivenine.UnifiedMaps
         public static readonly BindableProperty HasZoomEnabledProperty = BindableProperty.Create("HasZoomEnabled",
                 typeof(bool), typeof(UnifiedMap), true);
 
+		/// <summary>
+		/// The should display native zoom and location controls property (Android only).
+		/// </summary>
+		public static readonly BindableProperty ShouldDisplayNativeControlsProperty = BindableProperty.Create("ShouldDisplayNativeControls",
+				typeof(bool), typeof(UnifiedMap), false); // false by default to match with iOS
+
         /// <summary>
         /// The selected item property.
         /// </summary>
@@ -73,6 +79,13 @@ namespace fivenine.UnifiedMaps
         /// </summary>
         public static readonly BindableProperty SelectionChangedCommandProperty = BindableProperty.Create("SelectionChangedCommand",
                 typeof(Command<IMapAnnotation>), typeof(UnifiedMap), null);
+
+
+		/// <summary>
+		/// The property to indicate if deselection should occur when touching map.
+		/// </summary>
+		public static readonly BindableProperty ShouldDeselectOnMapTouchProperty = BindableProperty.Create("ShouldDeselectOnMapTouch",
+				typeof(bool), typeof(UnifiedMap), true);
 
         public static readonly BindableProperty VisibleRegionProperty = BindableProperty.Create("VisibleRegion",
                 typeof(MapRegion), typeof(UnifiedMap), null, propertyChanged: OnVisibleRegionChanged);
@@ -208,6 +221,30 @@ namespace fivenine.UnifiedMaps
             get { return (bool)GetValue(HasZoomEnabledProperty); }
             set { SetValue(HasZoomEnabledProperty, value); }
         }
+
+		/// <summary>
+		/// Gets or sets a value indicating deselection should occur when touching map.
+		/// </summary>
+		/// <value>
+		/// <c>true</c> if deselection should be enabled; otherwise, <c>false</c>.
+		/// </value>
+		public bool ShouldDeselectOnMapTouch
+		{
+			get { return (bool)GetValue(ShouldDeselectOnMapTouchProperty); }
+			set { SetValue(ShouldDeselectOnMapTouchProperty, value); }
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating if native zoom and location controls should be displayed (Android only).
+		/// </summary>
+		/// <value>
+		/// <c>true</c> if controls should be enabled; otherwise, <c>false</c>.
+		/// </value>
+		public bool ShouldDisplayNativeControls
+		{
+			get { return (bool)GetValue(ShouldDisplayNativeControlsProperty); }
+			set { SetValue(ShouldDisplayNativeControlsProperty, value); }
+		}
 
         /// <summary>
         /// Gets the visible region.


### PR DESCRIPTION
Another enhancement and bug fix. I added two conditional flags:

1. ShouldDeselectOnMapTouch
- This property controls if touching map will deselect items
2. ShouldDisplayNativeControls
- This property controls the show/hide of zoom button and location button on Android platform. iOS map does not natively have these controls.

Also fixed an issue where touch map to dismiss was not properly working on iOS.

It would be great if you could merge and update nuget please? Thank you :-)