### PR TITLE
Fix an issue where native controls are still shown when disabled

### DIFF
--- a/UnifiedMap/UnifiedMap/RendererBehavior.cs
+++ b/UnifiedMap/UnifiedMap/RendererBehavior.cs
@@ -290,6 +290,7 @@ namespace fivenine.UnifiedMaps
             _renderer.ApplyHasScrollEnabled();
             _renderer.ApplyHasZoomEnabled();
             _renderer.ApplyIsShowingUser();
+            _renderer.ApplyDisplayNativeControls();
 
             AddAllPins();
             AddAllOverlays();


### PR DESCRIPTION
ApplyDisplayNativeControl method was not called during initialisation therefore the location button is still shown on Android when it's specifically set to false. 