### PR TITLE
Enhance map with ability to choose whether to show callout on tap or not

### DIFF
--- a/UnifiedMap/UnifiedMap.Droid/UnifiedMapRenderer.cs
+++ b/UnifiedMap/UnifiedMap.Droid/UnifiedMapRenderer.cs
@@ -413,7 +413,7 @@ namespace fivenine.UnifiedMaps.Droid
             var markerView = _googleMap.AddMarker(mapPin);
             _markers.Add(pin, markerView);
 
-            if (selected)
+            if (selected && Map.CanShowCalloutOnTap)
             {
                 markerView.ShowInfoWindow();
             }

--- a/UnifiedMap/UnifiedMap.iOS/UnifiedMapDelegate.cs
+++ b/UnifiedMap/UnifiedMap.iOS/UnifiedMapDelegate.cs
@@ -62,7 +62,7 @@ namespace fivenine.UnifiedMaps.iOS
                 }
 
                 // Only show the callout if there is something to display
-                annotationView.CanShowCallout = string.IsNullOrWhiteSpace(pinAnnotation.Data.Title) == false;
+                annotationView.CanShowCallout = _renderer.Element.CanShowCalloutOnTap && !string.IsNullOrWhiteSpace(pinAnnotation.Data.Title);
 
                 if (annotationView.CanShowCallout
                     && _renderer.Element.PinCalloutTappedCommand != null

--- a/UnifiedMap/UnifiedMap/UnifiedMap.cs
+++ b/UnifiedMap/UnifiedMap/UnifiedMap.cs
@@ -39,6 +39,12 @@ namespace fivenine.UnifiedMaps
             BindableProperty.Create("PinCalloutTappedCommand", typeof (Command<IMapPin>), typeof (UnifiedMap), null);
 
         /// <summary>
+        /// The can show callout on tap property.
+        /// </summary>
+        public static readonly BindableProperty CanShowCalloutOnTapProperty = BindableProperty.Create("CanShowCalloutOnTap",
+            typeof (bool), typeof (UnifiedMap), true);
+        
+        /// <summary>
         /// The autofitallannotations property.
         /// </summary>
         public static readonly BindableProperty AutoFitAllAnnotationsProperty = BindableProperty.Create("AutoFitAllAnnotations",
@@ -172,6 +178,18 @@ namespace fivenine.UnifiedMaps
         {
             get { return (Command<IMapPin>)GetValue(PinCalloutTappedCommandProperty); }
             set { SetValue(PinCalloutTappedCommandProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets whether to show callout on tap.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if show callout on tap should be enabled; otherwise, <c>false</c>.
+        /// </value>
+        public bool CanShowCalloutOnTap
+        {
+            get { return (bool)GetValue(CanShowCalloutOnTapProperty); }
+            set { SetValue(CanShowCalloutOnTapProperty, value); }
         }
 
         /// <summary>


### PR DESCRIPTION
Currently map pin with title always shows callout. This enhances map with a boolean - CanShowCalloutOnTap - to allow devs to choose whether to show callout on tap or not.