### PR TITLE
Fix ‘CoreAnimation: zPosition should be within (-FLT_MAX, FLT_MAX) range’ issue on iOS

### DIFF
--- a/UnifiedMap/UnifiedMap.iOS/UnifiedMapDelegate.cs
+++ b/UnifiedMap/UnifiedMap.iOS/UnifiedMapDelegate.cs
@@ -112,7 +112,7 @@ namespace fivenine.UnifiedMaps.iOS
 
                 UpdateImage(view, unifiedPoint.Data, isSelected);
                 UpdatePin(view, unifiedPoint.Data, true);
-                view.Layer.ZPosition = nfloat.MaxValue - 1;
+                view.Layer.ZPosition = int.MaxValue - 1;
             }
         }
 
@@ -125,11 +125,11 @@ namespace fivenine.UnifiedMaps.iOS
                 var myClass = classHandle != IntPtr.Zero ? new Class(classHandle) : null;
                 if (myClass != null && view.IsKindOfClass(myClass))
                 {
-                    view.Layer.ZPosition = nfloat.MaxValue;
+                    view.Layer.ZPosition = int.MaxValue;
                 }
                 else if (view.Annotation is MKUserLocation)
                 {
-                    view.Layer.ZPosition = nfloat.MaxValue;
+                    view.Layer.ZPosition = int.MaxValue;
                 }
             }
         }


### PR DESCRIPTION
Fix ‘CoreAnimation: zPosition should be within (-FLT_MAX, FLT_MAX) range’ issue on iOS