### PR TITLE
Fix #51 Map controls interfering with each other with MoveToRegion is invoked

### DIFF
--- a/UnifiedMap/UnifiedMap/RendererBehavior.cs
+++ b/UnifiedMap/UnifiedMap/RendererBehavior.cs
@@ -55,18 +55,18 @@ namespace fivenine.UnifiedMaps
             RegisterPinEvents(map);
             RegisterOverlayEvents(map);
 
-            MessagingCenter.Subscribe<UnifiedMap, Tuple<MapRegion, bool>>(this, UnifiedMap.MessageMapMoveToRegion,
+            MessagingCenter.Subscribe<UnifiedMap, Tuple<MapRegion, bool>>(this, map.GetMoveToRegionMessage(),
                 (unifiedMap, span) => MoveToRegion(span.Item1, span.Item2));
 
-            MessagingCenter.Subscribe<UnifiedMap, bool>(this, UnifiedMap.MessageMapMoveToUserLocation,
+            MessagingCenter.Subscribe<UnifiedMap, bool>(this, map.GetMoveToUserLocationMessage(),
                 (unifiedMap, animated) => MoveToUserLocation(animated));
             
         }
 
         internal void RemoveEvents(UnifiedMap map)
         {
-            MessagingCenter.Unsubscribe<UnifiedMap, Tuple<MapRegion, bool>>(this, UnifiedMap.MessageMapMoveToRegion);
-            MessagingCenter.Unsubscribe<UnifiedMap, bool>(this, UnifiedMap.MessageMapMoveToUserLocation);
+            MessagingCenter.Unsubscribe<UnifiedMap, Tuple<MapRegion, bool>>(this, map.GetMoveToRegionMessage());
+            MessagingCenter.Unsubscribe<UnifiedMap, bool>(this, map.GetMoveToUserLocationMessage());
 
             RemovePinEvents();
             RemoveOverlayEvents();

--- a/UnifiedMap/UnifiedMap/UnifiedMap.cs
+++ b/UnifiedMap/UnifiedMap/UnifiedMap.cs
@@ -12,9 +12,6 @@ namespace fivenine.UnifiedMaps
 	[Preserve(AllMembers = true)]
     public class UnifiedMap : View
     {
-        internal const string MessageMapMoveToRegion = "MapMoveToRegion";
-        internal const string MessageMapMoveToUserLocation= "MessageMapMoveToUserLocation";
-
         /// <summary>
         /// Identifies the <see cref="MapType"/> bindable property.
         /// </summary>
@@ -361,12 +358,12 @@ namespace fivenine.UnifiedMaps
                 animated = false;
             }
             // Send the move message to the platform renderer
-            MessagingCenter.Send(this, MessageMapMoveToRegion, new Tuple<MapRegion, bool>(region, animated));
+            MessagingCenter.Send(this, this.GetMoveToRegionMessage(), new Tuple<MapRegion, bool>(region, animated));
         }
 
         public void MoveToUserLocation(bool animated = false) {
             
-            MessagingCenter.Send(this, MessageMapMoveToUserLocation, animated);
+            MessagingCenter.Send(this, this.GetMoveToUserLocationMessage(), animated);
         }
     }
 }

--- a/UnifiedMap/UnifiedMap/Util.cs
+++ b/UnifiedMap/UnifiedMap/Util.cs
@@ -8,6 +8,9 @@ namespace fivenine.UnifiedMaps
     /// </summary>
     public static class Util
     {
+        internal const string MessageMapMoveToRegion = "MapMoveToRegion";
+        internal const string MessageMapMoveToUserLocation = "MessageMapMoveToUserLocation";
+
         /// <summary>
         /// Clamps the given value to the specified range.
         /// </summary>
@@ -61,5 +64,14 @@ namespace fivenine.UnifiedMaps
             return new Position(centralLatitude * 180 / Math.PI, centralLongitude * 180 / Math.PI);
         }
 
+        internal static string GetMoveToRegionMessage(this UnifiedMap map)
+        {
+            return $"{MessageMapMoveToRegion}-{map.GetHashCode()}";
+        }
+
+        internal static string GetMoveToUserLocationMessage(this UnifiedMap map)
+        {
+            return $"{MessageMapMoveToUserLocation}-{map.GetHashCode()}";
+        }
     }
 }


### PR DESCRIPTION
Appending map's hash code to differentiate between maps when MoveToRegion and MoveToUserLocation is invoked.