### PR TITLE
Add new property to set visible area on ios

### DIFF
--- a/SampleApp/SampleApp/MapPage.xaml
+++ b/SampleApp/SampleApp/MapPage.xaml
@@ -21,6 +21,7 @@
                 HasZoomEnabled="{Binding HasZoomEnabled}"
     			SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
                 CameraAnimationEnabled="{Binding CameraAnimationEnabled}"
+                IosSingleAnnotationZoom="0.01"
                 HeightRequest="100"
                 WidthRequest="960"
                 ZoomLevel="16"

--- a/UnifiedMap/UnifiedMap.iOS/UnifiedMapRenderer.cs
+++ b/UnifiedMap/UnifiedMap.iOS/UnifiedMapRenderer.cs
@@ -72,7 +72,7 @@ namespace fivenine.UnifiedMaps.iOS
             if(Control.Annotations.Length == 1) 
             {
                 var singleAnnotation = Control.Annotations[0];
-                var region = new MapRegion(new Position(singleAnnotation.Coordinate.Latitude, singleAnnotation.Coordinate.Longitude), 0.01, 0.01);
+                var region = new MapRegion(new Position(singleAnnotation.Coordinate.Latitude, singleAnnotation.Coordinate.Longitude), Element.IosSingleAnnotationZoom, Element.IosSingleAnnotationZoom);
                 MoveToRegion(region, animated);
             } 
             else 

--- a/UnifiedMap/UnifiedMap/UnifiedMap.cs
+++ b/UnifiedMap/UnifiedMap/UnifiedMap.cs
@@ -90,12 +90,17 @@ namespace fivenine.UnifiedMaps
         public static readonly BindableProperty SelectionChangedCommandProperty = BindableProperty.Create("SelectionChangedCommand",
                 typeof(Command<IMapAnnotation>), typeof(UnifiedMap), null);
 
-
         /// <summary>
         /// The initial zoom level of the map, -1 will ignore this property (Android only).
         /// </summary>
         public static readonly BindableProperty ZoomLevelProperty = BindableProperty.Create(nameof(ZoomLevel),  
                 typeof(int), typeof(UnifiedMap), -1);
+
+        /// <summary>
+        /// The Zoom level for Apples MapKit if only one Annotation is visible, defaults to 0.005
+        /// </summary>
+        public static readonly BindableProperty IosSingleAnnotationZoomProperty = BindableProperty.Create(nameof(IosSingleAnnotationZoom),
+                typeof(double), typeof(UnifiedMap), 0.005);
         
 		/// <summary>
 		/// The property to indicate if deselection should occur when touching map.
@@ -309,6 +314,18 @@ namespace fivenine.UnifiedMaps
         {
             get { return (int)GetValue(ZoomLevelProperty); }
             set { SetValue(ZoomLevelProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets the zoom level for iOS if only a sinlge annotation is visible.
+        /// </summary>
+        /// <value>
+        /// The zoom level.
+        /// </value>
+        public double IosSingleAnnotationZoom
+        {
+            get { return (double)GetValue(IosSingleAnnotationZoomProperty); }
+            set { SetValue(IosSingleAnnotationZoomProperty, value); }
         }
 
             /// <summary>


### PR DESCRIPTION
adds property to set width/height of map if only one annotation is visible on ios