### PR TITLE
Exclude UserLocation from FitAllAnnotations on iOS

### DIFF
--- a/UnifiedMap/UnifiedMap.iOS/UnifiedMapRenderer.cs
+++ b/UnifiedMap/UnifiedMap.iOS/UnifiedMapRenderer.cs
@@ -36,7 +36,7 @@ namespace fivenine.UnifiedMaps.iOS
         public IMapAnnotation SelectedItem
         {
             get { return Element.SelectedItem; }
-            set 
+            set
             {
 				if (!Element.SelectedItem.EqualsSafe(value))
                 {
@@ -71,15 +71,28 @@ namespace fivenine.UnifiedMaps.iOS
 
         public void FitAllAnnotations(bool animated)
         {
-            if(Control.Annotations.Length == 1) 
+            if(Control.Annotations.Length == 1)
             {
                 var singleAnnotation = Control.Annotations[0];
                 var region = new MapRegion(new Position(singleAnnotation.Coordinate.Latitude, singleAnnotation.Coordinate.Longitude), Element.IosSingleAnnotationZoom, Element.IosSingleAnnotationZoom);
                 MoveToRegion(region, animated);
-            } 
-            else 
+            }
+            else
             {
-                Control.ShowAnnotations(Control.Annotations, animated);    
+                if(Map.ExcludeUserLocationFromFitAllAnnotations)
+                {
+                    var unifiedAnnotations = Control.Annotations.OfType<IUnifiedAnnotation>()
+                                            .Cast<IMKAnnotation>()
+                                            .ToArray();
+
+                    Debug.WriteLine("FitAllAnnotations() ExcludeUserLocationFromFitAllAnnotations");
+                    Control.ShowAnnotations(unifiedAnnotations, animated);
+                }
+                else
+                {
+                  Debug.WriteLine("FitAllAnnotations() ShowAll");
+                  Control.ShowAnnotations(Control.Annotations, animated);
+                }
             }
         }
 
@@ -205,7 +218,7 @@ namespace fivenine.UnifiedMaps.iOS
         {
             var newItem = Control.Annotations
                 .OfType<IUnifiedAnnotation>()
-                .FirstOrDefault(point => point.Data == SelectedItem) 
+                .FirstOrDefault(point => point.Data == SelectedItem)
                  as IMKAnnotation;
 
             if (newItem == null)
@@ -216,7 +229,7 @@ namespace fivenine.UnifiedMaps.iOS
 
                 return;
             }
-			
+
             Control.SelectAnnotation(newItem, true);
         }
 
@@ -330,6 +343,6 @@ namespace fivenine.UnifiedMaps.iOS
             _behavior.RemoveEvents(map);
         }
 
-  
+
     }
 }

--- a/UnifiedMap/UnifiedMap.iOS/UnifiedMapRenderer.cs
+++ b/UnifiedMap/UnifiedMap.iOS/UnifiedMapRenderer.cs
@@ -85,12 +85,10 @@ namespace fivenine.UnifiedMaps.iOS
                                             .Cast<IMKAnnotation>()
                                             .ToArray();
 
-                    Debug.WriteLine("FitAllAnnotations() ExcludeUserLocationFromFitAllAnnotations");
                     Control.ShowAnnotations(unifiedAnnotations, animated);
                 }
                 else
                 {
-                  Debug.WriteLine("FitAllAnnotations() ShowAll");
                   Control.ShowAnnotations(Control.Annotations, animated);
                 }
             }

--- a/UnifiedMap/UnifiedMap/UnifiedMap.cs
+++ b/UnifiedMap/UnifiedMap/UnifiedMap.cs
@@ -150,6 +150,8 @@ namespace fivenine.UnifiedMaps
             }
         }
 
+        public bool ExcludeUserLocationFromFitAllAnnotations { get; set; }
+
         /// <summary>
         /// The <see cref="MapType"/> display style of this <see cref="UnifiedMap"/>.
         /// </summary>


### PR DESCRIPTION
Add a new property for excluding userlocation if FitAllAnnotations is used, affects iOS only